### PR TITLE
[FIX] 예약 생성 예외 추가

### DIFF
--- a/src/main/java/com/Ureka/AnalDoo/common/exception/errorcode/ReservationErrorCode.java
+++ b/src/main/java/com/Ureka/AnalDoo/common/exception/errorcode/ReservationErrorCode.java
@@ -6,14 +6,14 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ReservationErrorCode implements ErrorCode{
+public enum ReservationErrorCode implements ErrorCode {
 
-    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND,"예약을 찾을 수 없습니다."),
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."),
     RESERVATION_USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "예약 주체가 아닙니다"),
     RESERVATION_CLOSED(HttpStatus.BAD_REQUEST, "이미 모집이 마감된 대회입니다."),
     RESERVATION_FULL(HttpStatus.BAD_REQUEST, "모집 인원을 초과할 수 없습니다."),
-    RESERVATION_ALREADY_EXISTS(HttpStatus.FORBIDDEN, "이미 예약한 대회입니다."),
-    RESERVATION_HOST_NOT_ALLOWED(HttpStatus.FORBIDDEN, "내가 주최한 대회는 예약할 수 없습니다."),
+    RESERVATION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 예약한 대회입니다."),
+    RESERVATION_HOST_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "내가 주최한 대회는 예약할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/Ureka/AnalDoo/common/exception/errorcode/ReservationErrorCode.java
+++ b/src/main/java/com/Ureka/AnalDoo/common/exception/errorcode/ReservationErrorCode.java
@@ -12,6 +12,8 @@ public enum ReservationErrorCode implements ErrorCode{
     RESERVATION_USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "예약 주체가 아닙니다"),
     RESERVATION_CLOSED(HttpStatus.BAD_REQUEST, "이미 모집이 마감된 대회입니다."),
     RESERVATION_FULL(HttpStatus.BAD_REQUEST, "모집 인원을 초과할 수 없습니다."),
+    RESERVATION_ALREADY_EXISTS(HttpStatus.FORBIDDEN, "이미 예약한 대회입니다."),
+    RESERVATION_HOST_NOT_ALLOWED(HttpStatus.FORBIDDEN, "내가 주최한 대회는 예약할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/Ureka/AnalDoo/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/Ureka/AnalDoo/domain/reservation/repository/ReservationRepository.java
@@ -1,10 +1,10 @@
 package com.Ureka.AnalDoo.domain.reservation.repository;
 
 import com.Ureka.AnalDoo.common.exception.RestApiException;
-import com.Ureka.AnalDoo.common.exception.errorcode.CompetitionErrorCode;
 import com.Ureka.AnalDoo.common.exception.errorcode.ReservationErrorCode;
 import com.Ureka.AnalDoo.domain.entity.Competition;
 import com.Ureka.AnalDoo.domain.entity.Reservation;
+import com.Ureka.AnalDoo.domain.entity.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,16 +12,18 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReservationRepository extends JpaRepository<Reservation,Long> {
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
 
-    Optional<Reservation> findByIdAndIsDeleted(Long id,boolean isDeleted);
+    Optional<Reservation> findByIdAndIsDeleted(Long id, boolean isDeleted);
 
     @Query("select r from Reservation r where r.competition.id =:competitionId and r.isDeleted = false")
     List<Reservation> findByCompetitionId(Long competitionId);
 
+    Optional<Reservation> getByUserAndCompetition(User user, Competition competition);
 
     default Reservation getById(Long id) {
-        return findByIdAndIsDeleted(id,false).orElseThrow(() -> new RestApiException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        return findByIdAndIsDeleted(id, false).orElseThrow(
+                () -> new RestApiException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     }
 }

--- a/src/main/java/com/Ureka/AnalDoo/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/Ureka/AnalDoo/domain/reservation/repository/ReservationRepository.java
@@ -20,7 +20,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("select r from Reservation r where r.competition.id =:competitionId and r.isDeleted = false")
     List<Reservation> findByCompetitionId(Long competitionId);
 
-    Optional<Reservation> getByUserAndCompetition(User user, Competition competition);
+    Optional<Reservation> findByUserAndCompetition(User user, Competition competition);
 
     default Reservation getById(Long id) {
         return findByIdAndIsDeleted(id, false).orElseThrow(

--- a/src/main/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceImpl.java
@@ -9,7 +9,6 @@ import com.Ureka.AnalDoo.domain.entity.Payment;
 import com.Ureka.AnalDoo.domain.entity.enums.CompetitionStatus;
 import com.Ureka.AnalDoo.domain.entity.Reservation;
 import com.Ureka.AnalDoo.domain.entity.User;
-import com.Ureka.AnalDoo.domain.entity.enums.PaymentStatus;
 import com.Ureka.AnalDoo.domain.payment.repository.PaymentRepository;
 import com.Ureka.AnalDoo.domain.payment.service.PaymentService;
 import com.Ureka.AnalDoo.domain.reservation.dto.request.ReservationCreateRequest;
@@ -43,7 +42,7 @@ public class ReservationServiceImpl implements ReservationService {
 
         validateReservationAvailable(user, competition);
 
-        Optional<Reservation> existedReservationOpt = reservationRepository.getByUserAndCompetition(user, competition);
+        Optional<Reservation> existedReservationOpt = reservationRepository.findByUserAndCompetition(user, competition);
 
         if (existedReservationOpt.isPresent()) {
             Reservation existedReservation = existedReservationOpt.get();

--- a/src/main/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceImpl.java
@@ -17,6 +17,7 @@ import com.Ureka.AnalDoo.domain.reservation.dto.response.ReservationCreateRespon
 import com.Ureka.AnalDoo.domain.reservation.repository.ReservationRepository;
 import com.Ureka.AnalDoo.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,8 +30,9 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final CompetitionRepository competitionRepository;
-    private final PaymentService paymentService;
+    private final PaymentRepository paymentRepository;
 
+    private final PaymentService paymentService;
 
     @Transactional
     @Override
@@ -39,16 +41,43 @@ public class ReservationServiceImpl implements ReservationService {
         Competition competition = competitionRepository.findByIdWithLock(request.getCompetitionId())
                 .orElseThrow(() -> new RestApiException(CompetitionErrorCode.COMPETITION_NOT_FOUND));
 
-        validateReservationAvailable(competition);
+        validateReservationAvailable(user, competition);
 
-        Reservation reservation = Reservation.of(user, competition);
-        Reservation savedReservation = reservationRepository.save(reservation);
-        competition.increaseEntryCount();
+        Optional<Reservation> existedReservationOpt = reservationRepository.getByUserAndCompetition(user, competition);
 
-        return ReservationCreateResponse.from(savedReservation);
+        if (existedReservationOpt.isPresent()) {
+            Reservation existedReservation = existedReservationOpt.get();
+            Payment payment = paymentRepository.findByReservationId(existedReservation.getId())
+                    .orElseThrow(() -> new RestApiException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+            switch (payment.getPaymentStatus()) {
+                case READY -> {
+                    return ReservationCreateResponse.from(existedReservation);
+                }
+                case PAID -> {
+                    throw new RestApiException(ReservationErrorCode.RESERVATION_ALREADY_EXISTS);
+                }
+                default -> throw new RestApiException(ReservationErrorCode.RESERVATION_ALREADY_EXISTS);
+            }
+        }
+
+        return createNewReservation(user, competition);
     }
 
-    private void validateReservationAvailable(Competition competition) {
+    private ReservationCreateResponse createNewReservation(User user, Competition competition) {
+        Reservation reservation = Reservation.of(user, competition);
+        competition.increaseEntryCount();
+
+        Reservation saved = reservationRepository.save(reservation);
+
+        return ReservationCreateResponse.from(saved);
+    }
+
+    private void validateReservationAvailable(User user,Competition competition) {
+        if (competition.getManager().getId().equals(user.getId())) {
+            throw new RestApiException(ReservationErrorCode.RESERVATION_HOST_NOT_ALLOWED);
+        }
+
         LocalDateTime now = LocalDateTime.now();
 
         if (competition.getStatus() == CompetitionStatus.CLOSED || competition.getPeriod().getEndDate().isBefore(now)) {
@@ -76,7 +105,6 @@ public class ReservationServiceImpl implements ReservationService {
         competition.decreaseEntryCount();
 
         paymentService.cancelPayment(reservation);
-
     }
 
     private void validateReservationRemove(final Reservation reservation,final User user){
@@ -84,6 +112,5 @@ public class ReservationServiceImpl implements ReservationService {
         if(!reservation.getUser().getId().equals(user.getId())){
             throw new RestApiException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
         }
-
     }
 }

--- a/src/test/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceTest.java
@@ -9,7 +9,6 @@ import com.Ureka.AnalDoo.common.exception.RestApiException;
 import com.Ureka.AnalDoo.common.exception.errorcode.ReservationErrorCode;
 import com.Ureka.AnalDoo.domain.competition.repository.CompetitionRepository;
 import com.Ureka.AnalDoo.domain.entity.Competition;
-import com.Ureka.AnalDoo.domain.entity.Payment;
 import com.Ureka.AnalDoo.domain.entity.Reservation;
 import com.Ureka.AnalDoo.domain.entity.User;
 import com.Ureka.AnalDoo.domain.entity.enums.CompetitionStatus;
@@ -173,7 +172,7 @@ class ReservationServiceTest {
 
         given(userRepository.getByEmail(userEmail)).willReturn(user);
         given(competitionRepository.findByIdWithLock(competitionId)).willReturn(Optional.of(competition));
-        given(reservationRepository.getByUserAndCompetition(user, competition)).willReturn(Optional.of(reservation));
+        given(reservationRepository.findByUserAndCompetition(user, competition)).willReturn(Optional.of(reservation));
         given(paymentRepository.findByReservationId(reservation.getId()))
                 .willReturn(Optional.of(PaymentFixture.createPayment(reservation, PaymentStatus.PAID)));
 

--- a/src/test/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/Ureka/AnalDoo/domain/reservation/service/ReservationServiceTest.java
@@ -9,14 +9,18 @@ import com.Ureka.AnalDoo.common.exception.RestApiException;
 import com.Ureka.AnalDoo.common.exception.errorcode.ReservationErrorCode;
 import com.Ureka.AnalDoo.domain.competition.repository.CompetitionRepository;
 import com.Ureka.AnalDoo.domain.entity.Competition;
+import com.Ureka.AnalDoo.domain.entity.Payment;
 import com.Ureka.AnalDoo.domain.entity.Reservation;
 import com.Ureka.AnalDoo.domain.entity.User;
 import com.Ureka.AnalDoo.domain.entity.enums.CompetitionStatus;
+import com.Ureka.AnalDoo.domain.entity.enums.PaymentStatus;
+import com.Ureka.AnalDoo.domain.payment.repository.PaymentRepository;
 import com.Ureka.AnalDoo.domain.reservation.dto.request.ReservationCreateRequest;
 import com.Ureka.AnalDoo.domain.reservation.dto.response.ReservationCreateResponse;
 import com.Ureka.AnalDoo.domain.reservation.repository.ReservationRepository;
 import com.Ureka.AnalDoo.domain.user.repository.UserRepository;
 import com.Ureka.AnalDoo.fixture.CompetitionFixture;
+import com.Ureka.AnalDoo.fixture.PaymentFixture;
 import com.Ureka.AnalDoo.fixture.ReservationFixture;
 import com.Ureka.AnalDoo.fixture.UserFixture;
 import java.util.Optional;
@@ -36,6 +40,8 @@ class ReservationServiceTest {
     private UserRepository userRepository;
     @Mock
     private CompetitionRepository competitionRepository;
+    @Mock
+    private PaymentRepository paymentRepository;
 
     @InjectMocks
     private ReservationServiceImpl reservationService;
@@ -44,11 +50,12 @@ class ReservationServiceTest {
     @DisplayName("정상적인 대회 예약 요청은 성공적으로 처리된다")
     void should_reserve_successfully_when_competition_is_open_and_valid() {
         // given
-        String userEmail = "1@naver.com";
+        String userEmail = "2@naver.com";
         Long competitionId = 1L;
 
-        User user = UserFixture.createUser("1@naver.com", "user1", "1111");
-        Competition competition = CompetitionFixture.createCompetitionWithId(competitionId, user,
+        User host = UserFixture.createUserWithId(1L, "1@naver.com", "user1", "1111");
+        User user = UserFixture.createUserWithId(2L, "2@naver.com", "user2", "2222");
+        Competition competition = CompetitionFixture.createCompetitionWithId(competitionId, host,
                 CompetitionStatus.OPEN, 10);
         Reservation reservation = ReservationFixture.createReservation(user, competition);
         ReservationCreateRequest request = new ReservationCreateRequest(competitionId);
@@ -68,11 +75,12 @@ class ReservationServiceTest {
     @DisplayName("모집 상태가 CLOSED인 경우 예약은 실패한다")
     void should_fail_reservation_when_competition_status_is_closed() {
         // given
-        String userEmail = "1@naver.com";
+        String userEmail = "2@naver.com";
         Long competitionId = 1L;
 
-        User user = UserFixture.createUser("1@naver.com", "user1", "1111");
-        Competition closedCompetition = CompetitionFixture.createCompetitionWithId(competitionId, user,
+        User host = UserFixture.createUserWithId(1L, "1@naver.com", "user1", "1111");
+        User user = UserFixture.createUserWithId(2L, "2@naver.com", "user2", "2222");
+        Competition closedCompetition = CompetitionFixture.createCompetitionWithId(competitionId, host,
                 CompetitionStatus.CLOSED, 10);
         ReservationCreateRequest request = new ReservationCreateRequest(competitionId);
 
@@ -89,11 +97,12 @@ class ReservationServiceTest {
     @DisplayName("모집 기간이 지난 대회는 예약이 불가능하다")
     void should_fail_reservation_when_competition_end_date_has_passed() {
         // given
-        String userEmail = "1@naver.com";
+        String userEmail = "2@naver.com";
         Long competitionId = 1L;
 
-        User user = UserFixture.createUser("1@naver.com", "user1", "1111");
-        Competition expiredCompetition = CompetitionFixture.createExpiredCompetition(competitionId, user);
+        User host = UserFixture.createUserWithId(1L, "1@naver.com", "user1", "1111");
+        User user = UserFixture.createUserWithId(2L, "2@naver.com", "user2", "2222");
+        Competition expiredCompetition = CompetitionFixture.createExpiredCompetition(competitionId, host);
         ReservationCreateRequest request = new ReservationCreateRequest(competitionId);
 
         given(userRepository.getByEmail(userEmail)).willReturn(user);
@@ -103,5 +112,74 @@ class ReservationServiceTest {
         assertThatThrownBy(() -> reservationService.create(request, user.getEmail()))
                 .isInstanceOf(RestApiException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ReservationErrorCode.RESERVATION_CLOSED);
+    }
+
+    @Test
+    @DisplayName("내가 주최한 대회는 예약이 불가능하다")
+    void should_fail_reservation_when_user_is_competition_host() {
+        // given
+        String userEmail = "1@naver.com";
+        Long competitionId = 1L;
+
+        User host = UserFixture.createUserWithId(1L, userEmail, "user1", "1111");
+        Competition competition = CompetitionFixture.createCompetitionWithId(competitionId, host,
+                CompetitionStatus.OPEN, 10);
+        ReservationCreateRequest request = new ReservationCreateRequest(competitionId);
+
+        given(userRepository.getByEmail(userEmail)).willReturn(host);
+        given(competitionRepository.findByIdWithLock(competitionId)).willReturn(Optional.of(competition));
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.create(request, host.getEmail()))
+                .isInstanceOf(RestApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ReservationErrorCode.RESERVATION_HOST_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("모집 인원이 꽉 찬 대회는 예약할 수 없다")
+    void should_fail_reservation_when_competition_is_full() {
+        // given
+        String userEmail = "2@naver.com";
+        Long competitionId = 1L;
+
+        User host = UserFixture.createUserWithId(1L, "1@naver.com", "user1", "1111");
+        User user = UserFixture.createUserWithId(2L, "2@naver.com", "user2", "2222");
+        Competition competition = CompetitionFixture.createCompetitionWithEntryCount(competitionId, host, 10, 10); // 정원:10, 현재:10
+        ReservationCreateRequest request = new ReservationCreateRequest(competitionId);
+
+        given(userRepository.getByEmail(userEmail)).willReturn(user);
+        given(competitionRepository.findByIdWithLock(competitionId)).willReturn(Optional.of(competition));
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.create(request, user.getEmail()))
+                .isInstanceOf(RestApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ReservationErrorCode.RESERVATION_FULL);
+    }
+
+
+    @Test
+    @DisplayName("이미 결제 완료된 예약이 존재하면 예약은 불가능하다")
+    void should_fail_reservation_when_paid_reservation_exists() {
+        // given
+        String userEmail = "2@naver.com";
+        Long competitionId = 1L;
+
+        User host = UserFixture.createUserWithId(1L, "1@naver.com", "user1", "1111");
+        User user = UserFixture.createUserWithId(2L, "2@naver.com", "user2", "2222");
+        Competition competition = CompetitionFixture.createCompetitionWithId(competitionId, host,
+                CompetitionStatus.OPEN, 10);
+        Reservation reservation = ReservationFixture.createReservation(user, competition);
+        ReservationCreateRequest request = new ReservationCreateRequest(competitionId);
+
+        given(userRepository.getByEmail(userEmail)).willReturn(user);
+        given(competitionRepository.findByIdWithLock(competitionId)).willReturn(Optional.of(competition));
+        given(reservationRepository.getByUserAndCompetition(user, competition)).willReturn(Optional.of(reservation));
+        given(paymentRepository.findByReservationId(reservation.getId()))
+                .willReturn(Optional.of(PaymentFixture.createPayment(reservation, PaymentStatus.PAID)));
+
+        // when & then
+        assertThatThrownBy(() -> reservationService.create(request, user.getEmail()))
+                .isInstanceOf(RestApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ReservationErrorCode.RESERVATION_ALREADY_EXISTS);
     }
 }

--- a/src/test/java/com/Ureka/AnalDoo/fixture/CompetitionFixture.java
+++ b/src/test/java/com/Ureka/AnalDoo/fixture/CompetitionFixture.java
@@ -33,6 +33,12 @@ public class CompetitionFixture {
         return competition;
     }
 
+    public static Competition createCompetitionWithEntryCount(Long id, User manager, int entryLimit, int currentEntryCount) {
+        Competition competition = createCompetitionWithId(id, manager, CompetitionStatus.OPEN, entryLimit);
+        ReflectionTestUtils.setField(competition, "currentEntryCount", currentEntryCount);
+        return competition;
+    }
+
     public static Competition createExpiredCompetition(Long competitionId, User manager) {
         Competition competition = Competition.of(
                 manager,

--- a/src/test/java/com/Ureka/AnalDoo/fixture/PaymentFixture.java
+++ b/src/test/java/com/Ureka/AnalDoo/fixture/PaymentFixture.java
@@ -1,0 +1,18 @@
+package com.Ureka.AnalDoo.fixture;
+
+import com.Ureka.AnalDoo.domain.entity.Payment;
+import com.Ureka.AnalDoo.domain.entity.Reservation;
+import com.Ureka.AnalDoo.domain.entity.enums.PayMethod;
+import com.Ureka.AnalDoo.domain.entity.enums.PaymentStatus;
+import java.math.BigDecimal;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PaymentFixture {
+
+    public static Payment createPayment(Reservation reservation, PaymentStatus status) {
+        Payment payment = Payment.createPayment("merchant123", "imp456", PayMethod.CARD, BigDecimal.valueOf(5000), reservation);
+        ReflectionTestUtils.setField(payment, "paymentStatus", status);
+        return payment;
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #43 

## 🏃‍ Task
- 자신이 개최한 대회는 예약이 불가하다.
- 이미 예약한 대회는 중복 예약이 불가하다.
- 결제중이던 예약은 기존에 생성된 예약을 반환한다.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?